### PR TITLE
allow skiping attachment checks if there's a problem in NSX conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,8 +137,13 @@ dmypy.json
 /src/normal.log.4
 /src/normal.log.5
 
-/src/data/notes/
-/src/data/test.nsx
 /cov_html/
 /scripts/mac-osx-build/secrets.py
 /src/logs/
+
+# Keep the src/data folder but none of its contents
+/src/data/
+!/src/data/.keep
+
+# Submodules
+/PyInquirer/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "PyInquirer"]
 	path = PyInquirer
-	url = https://github.com/kevindurston21/PyInquirer.git
+	url = https://github.com/kevindurston21/PyInquirer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See contributing guide [here](https://github.com/kevindurston21/YANOM-Note-O-Matic/wiki/Contributing).

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ beautifulsoup4==4.9.3
 filetype==1.0.7
 matplotlib==3.4.2
 packaging==21.0
-pandas==1.3.1
+pandas==1.3.5
 python-frontmatter==1.0.0

--- a/src/conversion_settings.py
+++ b/src/conversion_settings.py
@@ -387,6 +387,7 @@ class ConversionSettings:
         self.chart_image = True
         self.chart_csv = True
         self.chart_data_table = True
+        self.skip_attachment_checks = False
         self._allow_spaces_in_file_names = True
         self._allow_unicode_in_file_names = True
         self._allow_uppercase_in_file_names = True

--- a/src/interactive_cli.py
+++ b/src/interactive_cli.py
@@ -234,6 +234,8 @@ class StartUpCommandLineInterface(InquireCommandLineInterface):
             self._ask_and_set_space_replacement_character()
             self._ask_and_set_maximum_filename_length()
 
+        self._ask_about_attachment_check_level()
+
     def _ask_nimbus_conversion_options(self):
         self._ask_and_set_conversion_quick_setting()
         self._ask_and_set_source()
@@ -437,6 +439,21 @@ class StartUpCommandLineInterface(InquireCommandLineInterface):
 
         if 'First column of table as header column' in answers['table_options']:
             self._cli_conversion_settings.first_column_as_header = True
+
+    def _ask_about_attachment_check_level(self):
+        questions = [
+            {
+                'type': 'confirm',
+                'name': '_should_skip_checks',
+                'message': 'Do you wish to skip attachment checks? Only recommended if a previous run failed',
+                'default': False,
+            },
+        ]
+
+        answers = prompt(questions, style=self.style)
+        _exit_if_keyboard_interrupt(answers)
+
+        self._cli_conversion_settings.skip_attachment_checks = answers['_should_skip_checks']
 
     def _ask_and_set_chart_options(self):
         questions = [

--- a/src/notes_converter.py
+++ b/src/notes_converter.py
@@ -258,14 +258,21 @@ class NotesConvertor:
         if not config.yanom_globals.is_silent:
             with alive_bar(len(notes_to_check), bar='blocks') as bar:
                 for note in notes_to_check:
-                    self._nsx_attachment_checks(note, notes_to_check, bar)
+                    self._nsx_attachment_checks(note, notes_to_check, self.conversion_settings.skip_attachment_checks, bar)
             return
 
         for note in notes_to_check:
-            self._nsx_attachment_checks(note, notes_to_check)
+            self._nsx_attachment_checks(note, notes_to_check, self.conversion_settings.skip_attachment_checks)
 
-    def _nsx_attachment_checks(self, note, notes_to_check, bar=None):
-        content = note.read_text(encoding='utf-8')
+    def _nsx_attachment_checks(self, note, notes_to_check, skip_checks, bar=None):
+        error_mode = 'ignore' if skip_checks else 'strict'
+        content = None
+        try:
+            content = note.read_text(encoding='utf-8', errors=error_mode)
+        except UnicodeDecodeError:
+            print(f"\nNote {note} has error. Try again with loose error checking if you like\n")
+            exit(1)
+
         all_attachments_paths = find_local_file_links_in_content(self.conversion_settings.export_format,
                                                                  content)
 


### PR DESCRIPTION
I had issues with NSX -> HTML conversion due to the attachment check process. I also had some issues installing the repo. This PR:

1. Adds a `CONTRIBUTING.md` that links to your wiki
2. Updates pandas from `1.3.1` to `1.3.5` to resolve an issue I had installing from source.
3. Fixes the `.gitsubmodules` file so that the submodule actually works (for me at least)
4. Allows users to override attachment checking if they want to